### PR TITLE
Fargemodifiseringer i abacus og stolpediagram

### DIFF
--- a/src/charts/abacus/index.tsx
+++ b/src/charts/abacus/index.tsx
@@ -55,7 +55,7 @@ export const Abacus = <
   xMax,
   backgroundColor = "white",
   axisLineStroke = "black",
-  axisLineStrokeWidth = 5,
+  axisLineStrokeWidth = 2,
   axisTickStroke = "black",
   circleRadiusDefalt = 15,
   tickLength = 20,
@@ -78,11 +78,15 @@ export const Abacus = <
           scale={xScale}
           strokeWidth={axisLineStrokeWidth}
           stroke={axisLineStroke}
-          tickValues={[xMin, xMaxVal]}
+          numTicks={4}
           tickLength={tickLength}
           tickStroke={axisTickStroke}
           tickTransform={`translate(0,-${tickLength / 2})`}
           label={label}
+          labelProps={{
+            fontSize: 15,
+            textAnchor: "middle",
+          }}
         />
       </Group>
       <Group left={margin.left} top={margin.top}>

--- a/src/charts/abacus/index.tsx
+++ b/src/charts/abacus/index.tsx
@@ -1,5 +1,5 @@
 import { AxisBottom } from "@visx/axis";
-import { scaleLinear, scaleOrdinal } from "@visx/scale";
+import { scaleLinear } from "@visx/scale";
 import { Group } from "@visx/group";
 import { max } from "d3-array";
 
@@ -48,8 +48,6 @@ export const Abacus = <
     right: 20,
     left: 20,
   },
-  colorLegend = false,
-  colorBy,
   data,
   label,
   x,
@@ -62,13 +60,9 @@ export const Abacus = <
   circleRadiusDefalt = 15,
   tickLength = 20,
 }: AbacusProps<Data, X, ColorBy>) => {
-  // color legend missing
-  //tooltip missing
-
   const figData = data.concat(data.filter((d) => d["bohf"] === "Norge")[0]);
   const values = [...figData.flatMap((dt) => parseFloat(dt[x.toString()]))];
   const xMaxVal = xMax ? xMax : max(values) * 1.1;
-  const innerHeight = height - margin.top - margin.bottom;
   const innerWidth = width - margin.left - margin.right;
   const colors = ["#6CACE4", "#003087"];
 
@@ -99,7 +93,6 @@ export const Abacus = <
             cx={xScale(d[x])}
             opacity={0.8}
             fill={d["bohf"] === "Norge" ? colors[1] : colors[0]}
-            stroke={d["bohf"] === "Norge" ? "black" : "grey"}
           />
         ))}
       </Group>

--- a/src/charts/barcharts/index.tsx
+++ b/src/charts/barcharts/index.tsx
@@ -172,8 +172,7 @@ export const Barchart = <
             label={xLabel}
             labelProps={{
               fontSize: 15,
-              x: 50,
-              y: 30,
+              textAnchor: "middle",
             }}
           />
         </Group>

--- a/src/charts/barcharts/index.tsx
+++ b/src/charts/barcharts/index.tsx
@@ -115,7 +115,7 @@ export const Barchart = <
     : [];
   const values = [...annualValues, ...series.flat().flat().flat()];
   const xMaxValue = xMax ? xMax : max(values) * 1.1;
-  const colors = ["#003087", "#6CACE4"];
+  const colors = ["#6CACE4", "#003087"];
   const colorScale = scaleOrdinal({
     domain: series.map((s) => s.key),
     range: [...colors],
@@ -189,7 +189,11 @@ export const Barchart = <
                       y={yScale(barData.data[y].toString())}
                       width={xScale(Math.abs(barData[0] - barData[1]))}
                       height={yScale.bandwidth()}
-                      stroke={colors[0]}
+                      fill={
+                        barData.data["bohf"].toString() === "Norge"
+                          ? colors[1]
+                          : colors[0]
+                      }
                       strokeWidth={1}
                     />
                   );


### PR DESCRIPTION
- fjernet grå farge rundt rundinger (closes #296)
- Lysblå i stolpediagram (closes #297)
- Beholdt mørkeblå for Norge
- Fjernet noe kode som var grånet ut i vscode