### PR TITLE
Farger fra Figma i plott

### DIFF
--- a/src/charts/abacus/index.tsx
+++ b/src/charts/abacus/index.tsx
@@ -64,7 +64,7 @@ export const Abacus = <
   const values = [...figData.flatMap((dt) => parseFloat(dt[x.toString()]))];
   const xMaxVal = xMax ? xMax : max(values) * 1.1;
   const innerWidth = width - margin.left - margin.right;
-  const colors = ["#AB6CA6", "#68B39C"];
+  const colors = ["rgba(135, 24, 157, 0.6)", "rgba(0, 193, 159, 0.6)"];
 
   const xScale = scaleLinear<number>({
     domain: [xMin, xMaxVal],
@@ -95,7 +95,6 @@ export const Abacus = <
             key={`${d[x]}${i}`}
             r={circleRadiusDefalt}
             cx={xScale(d[x])}
-            opacity={0.8}
             fill={d["bohf"] === "Norge" ? colors[1] : colors[0]}
           />
         ))}

--- a/src/charts/abacus/index.tsx
+++ b/src/charts/abacus/index.tsx
@@ -64,7 +64,7 @@ export const Abacus = <
   const values = [...figData.flatMap((dt) => parseFloat(dt[x.toString()]))];
   const xMaxVal = xMax ? xMax : max(values) * 1.1;
   const innerWidth = width - margin.left - margin.right;
-  const colors = ["#6CACE4", "#003087"];
+  const colors = ["#AB6CA6", "#68B39C"];
 
   const xScale = scaleLinear<number>({
     domain: [xMin, xMaxVal],

--- a/src/charts/barcharts/index.tsx
+++ b/src/charts/barcharts/index.tsx
@@ -119,8 +119,16 @@ export const Barchart = <
   const values = [...annualValues, ...series.flat().flat().flat()];
   const xMaxValue = xMax ? xMax : max(values) * 1.1;
 
-  const colors = ["#AB6CA6", "#6CACE4", "#95bde6"];
-  const nationColors = ["#68B39C", "#969696", "#c3c3c3"];
+  const colors = [
+    "rgba(135, 24, 157, 1)",
+    "rgba(135, 24, 157, 0.8)",
+    "rgba(135, 24, 157, 0.6)",
+  ];
+  const nationColors = [
+    "rgba(0, 193, 159, 1)",
+    "rgba(0, 193, 159, 0.8)",
+    "rgba(0, 193, 159, 0.6)",
+  ];
 
   const colorScale = scaleOrdinal({
     domain: series.map((s) => s.key),
@@ -212,10 +220,10 @@ export const Barchart = <
                       fill={
                         barData.data["bohf"].toString() === "Norge"
                           ? x.length === 1
-                            ? nationColors[0]
+                            ? nationColors[1]
                             : nationColorScale(d["key"])
                           : x.length === 1
-                          ? colors[0]
+                          ? colors[1]
                           : colorScale(d["key"])
                       }
                     />

--- a/src/charts/barcharts/index.tsx
+++ b/src/charts/barcharts/index.tsx
@@ -220,10 +220,10 @@ export const Barchart = <
                       fill={
                         barData.data["bohf"].toString() === "Norge"
                           ? x.length === 1
-                            ? nationColors[1]
+                            ? nationColors[2]
                             : nationColorScale(d["key"])
                           : x.length === 1
-                          ? colors[1]
+                          ? colors[2]
                           : colorScale(d["key"])
                       }
                     />

--- a/src/charts/barcharts/index.tsx
+++ b/src/charts/barcharts/index.tsx
@@ -119,8 +119,8 @@ export const Barchart = <
   const values = [...annualValues, ...series.flat().flat().flat()];
   const xMaxValue = xMax ? xMax : max(values) * 1.1;
 
-  const colors = ["#003087", "#6CACE4", "#95bde6"];
-  const nationColors = ["#4c4c4c", "#969696", "#c3c3c3"];
+  const colors = ["#AB6CA6", "#6CACE4", "#95bde6"];
+  const nationColors = ["#68B39C", "#969696", "#c3c3c3"];
 
   const colorScale = scaleOrdinal({
     domain: series.map((s) => s.key),
@@ -212,18 +212,12 @@ export const Barchart = <
                       fill={
                         barData.data["bohf"].toString() === "Norge"
                           ? x.length === 1
-                            ? nationColors[2]
+                            ? nationColors[0]
                             : nationColorScale(d["key"])
                           : x.length === 1
-                          ? colors[2]
+                          ? colors[0]
                           : colorScale(d["key"])
                       }
-                      stroke={
-                        barData.data["bohf"].toString() === "Norge"
-                          ? nationColors[0]
-                          : colors[0]
-                      }
-                      strokeWidth={1}
                     />
                   );
                 })}


### PR DESCRIPTION
## Offisielle farger (`#87189D` og `#00C19F`)

![image](https://user-images.githubusercontent.com/136346/162688079-20e0b106-4738-48f7-8c62-c38c26cafd32.png)

## Offisielle farger med gjennomsiktighet (`rgba(135, 24, 157, 0.8)` f.eks.)

Det er dette som nå er brukt. Helseforetak har fargen `rgba(135, 24, 157, 0.6)` i abacus og `rgba(135, 24, 157, 0.8)` i stolpediagram. Norge har fargen `rgba(0, 193, 159, 0.6)` i abacus og `rgba(0, 193, 159, 0.8)` i stolpediagram.

![image](https://user-images.githubusercontent.com/136346/162708828-ef63c1a4-59d2-4aaa-98bc-d9b55fd80fe2.png)

## Offisielle farger med mer gjennomsiktighet i stolpe (`rgba(135, 24, 157, 0.6)`

![image](https://user-images.githubusercontent.com/136346/162725338-a696322c-1a2e-49eb-9246-74dd66dded15.png)


## Fra Figma (`#AB6CA6` og `#68B39C`)

![image](https://user-images.githubusercontent.com/136346/162688297-b70e6f02-b406-4a88-8864-c8e94f59841e.png)


