### PR TITLE
Change font size on barchart

### DIFF
--- a/src/charts/barcharts/index.tsx
+++ b/src/charts/barcharts/index.tsx
@@ -190,10 +190,11 @@ export const Barchart = <
             })}
             label={yLabel}
             labelProps={{
-              fontSize: 20,
-              x: -80,
+              fontSize: 14,
+              x: -127,
               y: -15,
               transform: "(rotateX(90deg))",
+              fontWeight: "bold",
             }}
           />
         </Group>
@@ -212,8 +213,9 @@ export const Barchart = <
             tickTransform={`translate(0,0)`}
             label={xLabel}
             labelProps={{
-              fontSize: 15,
+              fontSize: 14,
               textAnchor: "middle",
+              fontWeight: "bold",
             }}
           />
         </Group>


### PR DESCRIPTION
Bruke lik fontstørrelse som HF-navnene, men med fet skrift. Bruke fet skrift på x-aksen også. Dette blir også likere abacus-plottet, og vi reduserer fra tre forskjellige fontstørrelser til en fontstørrelse.

Closes #432