### PR TITLE
Flyttet rapportlenke til flytende tekst

### DIFF
--- a/_posts/tidligere_atlas/barn.md
+++ b/_posts/tidligere_atlas/barn.md
@@ -12,7 +12,7 @@ lang: nb
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske områdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/rapport_digitalt.pdf).
+Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske områdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/rapport_digitalt.pdf">rapporten</a>.
 </div>
 
 ## Barn 0–16 år, totalt

--- a/_posts/tidligere_atlas/barn.md
+++ b/_posts/tidligere_atlas/barn.md
@@ -6,14 +6,13 @@ mainTitle: Barnehelseatlas for Norge
 shortTitle: Barnehelseatlas
 image: /helseatlas/img/no/barn/frontpage.jpg
 frontpagetext: Barnehelseatlaset gir et innblikk i fordelingen av helsetjenester til barn i Norge. Tilsammen er 10,6 millioner kontakter mellom barn og helsetjenesten er analysert.
-pdfUrl: /helseatlas/files/rapport_digitalt.pdf
 ia: true
 toc: true
 lang: nb
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske områdene er kort kommentert.
+Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske områdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/rapport_digitalt.pdf).
 </div>
 
 ## Barn 0–16 år, totalt

--- a/_posts/tidligere_atlas/dagkir.md
+++ b/_posts/tidligere_atlas/dagkir.md
@@ -7,14 +7,13 @@ num: 1
 mainTitle: Dagkirurgi i Norge 2011–2013
 shortTitle: Dagkirurgi
 image: /helseatlas/img/no/dagkir/frontpage.jpg
-pdfUrl: /helseatlas/files/Rapporthelseatlas1_15.pdf
 ia: true
 toc: false
 lang: nb
 date: "2015-01-13T12:00:00.000Z"
 ---
 <div className="ingress">
-Hovedfunnene er oppsummert i faktaarkene under, som også inneholder en kort beskrivelse av tilstand og inngrep. Det gis videre informasjon om befolkningens forbruk av inngrepet i geografiske områder. Med forbruk menes andel av befolkningen som får utført inngrepet. Befolkningens forbruk måles som antall inngrep pr. 100 000 innbyggere. Forskjeller i forbruk mellom de geografiske områdene er kort kommentert.
+Hovedfunnene er oppsummert i faktaarkene under, som også inneholder en kort beskrivelse av tilstand og inngrep. Det gis videre informasjon om befolkningens forbruk av inngrepet i geografiske områder. Med forbruk menes andel av befolkningen som får utført inngrepet. Befolkningens forbruk måles som antall inngrep pr. 100 000 innbyggere. Forskjeller i forbruk mellom de geografiske områdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/Rapporthelseatlas1_15.pdf).
 </div>
 
 ### [Skulderkirurgi](/helseatlas/files/Skulderreseksjon.pdf) (Acromionreseksjon)

--- a/_posts/tidligere_atlas/dagkir.md
+++ b/_posts/tidligere_atlas/dagkir.md
@@ -13,7 +13,7 @@ lang: nb
 date: "2015-01-13T12:00:00.000Z"
 ---
 <div className="ingress">
-Hovedfunnene er oppsummert i faktaarkene under, som også inneholder en kort beskrivelse av tilstand og inngrep. Det gis videre informasjon om befolkningens forbruk av inngrepet i geografiske områder. Med forbruk menes andel av befolkningen som får utført inngrepet. Befolkningens forbruk måles som antall inngrep pr. 100 000 innbyggere. Forskjeller i forbruk mellom de geografiske områdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/Rapporthelseatlas1_15.pdf).
+Hovedfunnene er oppsummert i faktaarkene under, som også inneholder en kort beskrivelse av tilstand og inngrep. Det gis videre informasjon om befolkningens forbruk av inngrepet i geografiske områder. Med forbruk menes andel av befolkningen som får utført inngrepet. Befolkningens forbruk måles som antall inngrep pr. 100 000 innbyggere. Forskjeller i forbruk mellom de geografiske områdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/Rapporthelseatlas1_15.pdf">rapporten</a>.
 </div>
 
 ### [Skulderkirurgi](/helseatlas/files/Skulderreseksjon.pdf) (Acromionreseksjon)

--- a/_posts/tidligere_atlas/dagkir2.md
+++ b/_posts/tidligere_atlas/dagkir2.md
@@ -12,7 +12,7 @@ toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, og inneholder en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 100 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/dagkirurgi_2013-2017.pdf).
+Hovedfunnene er oppsummert under, og inneholder en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 100 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/dagkirurgi_2013-2017.pdf">rapporten</a>.
 </div>
 
 **Les mer:**[Opptaksområder og justering](/helseatlas/files/dagkir2_opptaksomr.pdf)

--- a/_posts/tidligere_atlas/dagkir2.md
+++ b/_posts/tidligere_atlas/dagkir2.md
@@ -6,14 +6,13 @@ mainTitle: Dagkirurgi i Norge 2013–2017
 shortTitle: Dagkirurgi
 image: /helseatlas/img/no/dagkir2/frontpage.jpg
 frontpagetext: I det andre helseatlaset på dagkirurgi beskrives utviklingen i omfang og variasjon mellom helseforetakenes opptaksområder for de samme tolv inngrepene som i det første dagkirurgiatlaset, denne gang for perioden 2013–2017.
-pdfUrl: /helseatlas/files/dagkirurgi_2013-2017.pdf
 ia: true
 lang: nb
 toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, og inneholder en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 100 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert.
+Hovedfunnene er oppsummert under, og inneholder en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 100 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/dagkirurgi_2013-2017.pdf).
 </div>
 
 **Les mer:**[Opptaksområder og justering](/helseatlas/files/dagkir2_opptaksomr.pdf)

--- a/_posts/tidligere_atlas/eldre.md
+++ b/_posts/tidligere_atlas/eldre.md
@@ -12,7 +12,7 @@ toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/eldrehelseatlas_rapport.pdf).
+Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/eldrehelseatlas_rapport.pdf">rapporten</a>.
 </div>
 
 ## Allmennlegetjenesten

--- a/_posts/tidligere_atlas/eldre.md
+++ b/_posts/tidligere_atlas/eldre.md
@@ -6,14 +6,13 @@ num: 4
 mainTitle: Eldrehelseatlas for Norge
 shortTitle: Eldrehelseatlas
 frontpagetext: Eldrehelseatlas for Norge beskriver variasjon i eldres bruk av sentrale somatiske spesialisthelsetjenester i forhold til bosted. 
-pdfUrl: /helseatlas/files/eldrehelseatlas_rapport.pdf
 ia: true
 lang: nb
 toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert.
+Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/eldrehelseatlas_rapport.pdf).
 </div>
 
 ## Allmennlegetjenesten

--- a/_posts/tidligere_atlas/fodsel.md
+++ b/_posts/tidligere_atlas/fodsel.md
@@ -6,14 +6,13 @@ num: 9
 mainTitle: Helseatlas for fødselshjelp
 shortTitle: Fødselshjelp
 frontpagetext: Helseatlas for fødselshjelp er det andre av to atlas innen gynekologi og fødselshjelp som er laget av SKDE etter initiativ fra Norsk gynekologisk forening.
-pdfUrl: /helseatlas/files/helseatlas-fodselshjelp.pdf
 ia: true
 toc: true
 lang: nb
 ---
 
 <div className="ingress">
-Hovedfunn fra Helseatlas for fødselshjelp er oppsummert under. Oppsummeringene inneholder også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert.
+Hovedfunn fra Helseatlas for fødselshjelp er oppsummert under. Oppsummeringene inneholder også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/helseatlas-fodselshjelp.pdf).
 </div>
 
 ## Fødsler i Norge

--- a/_posts/tidligere_atlas/fodsel.md
+++ b/_posts/tidligere_atlas/fodsel.md
@@ -12,7 +12,7 @@ lang: nb
 ---
 
 <div className="ingress">
-Hovedfunn fra Helseatlas for fødselshjelp er oppsummert under. Oppsummeringene inneholder også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/helseatlas-fodselshjelp.pdf).
+Hovedfunn fra Helseatlas for fødselshjelp er oppsummert under. Oppsummeringene inneholder også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 1 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/helseatlas-fodselshjelp.pdf">rapporten</a>.
 </div>
 
 ## Fødsler i Norge

--- a/_posts/tidligere_atlas/gyn.md
+++ b/_posts/tidligere_atlas/gyn.md
@@ -6,14 +6,13 @@ num: 8
 mainTitle: Helseatlas for gynekologi
 shortTitle: Gynekologi
 frontpagetext: I helseatlas for gynekologi har vi kartlagt geografisk variasjon i bruken av et utvalg av spesialisthelsetjenester innen gynekologi i perioden 2015–2017.
-pdfUrl: /helseatlas/files/helseatlas-gynekologi.pdf
 ia: true
 lang: nb
 toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert.
+Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/helseatlas-gynekologi.pdf).
 </div>
 
 **Les mer:** [Opptaksområder og justering](/helseatlas/files/gyn_opptaksomr.pdf)

--- a/_posts/tidligere_atlas/gyn.md
+++ b/_posts/tidligere_atlas/gyn.md
@@ -159,7 +159,7 @@ Den geografiske variasjonen i bruken av kirurgisk metode ved selvbestemt abort e
 
 ## Prøverørsbehandling
 
-2015–2017Dersom et par aktivt har forsøkt å bli gravide i ett år uten å lykkes, defineres de som ufrivillig barnløse. Ufrivillig barnløse kan få hjelp til å forsøke å bli gravide. I perioden 2015–2017 ble årlig ca 2 500 norske barn født etter assistert befruktning. Dette utgjør ca. 4 % av alle barn som blir født i Norge hvert år.
+Dersom et par aktivt har forsøkt å bli gravide i ett år uten å lykkes, defineres de som ufrivillig barnløse. Ufrivillig barnløse kan få hjelp til å forsøke å bli gravide. I perioden 2015–2017 ble årlig ca 2 500 norske barn født etter assistert befruktning. Dette utgjør ca. 4 % av alle barn som blir født i Norge hvert år.
 
 Det er ulike metoder for assistert befruktning. IVF-behandling, (in vitro-fertilisering), også kalt prøverørsbehandling, er den mest benyttede metoden for assistert befruktning. Prinsippet er at kvinnens eggcelle hentes ut fra eggstokken. Sædceller tilsettes og befruktning skjer i glass-skålen. Det befruktede egget deler seg over 2–5 døgn og blir til et tidlig fosteranlegg (embryo). Embryoet settes tilbake i kvinnens livmor. Ved overskudd av embryo kan disse fryses ned til senere bruk.
 
@@ -185,7 +185,7 @@ Det er ingen kjent geografisk variasjon i infertilitet som skulle tilsi at bruke
 
 ## Endometriose
 
-2015–2017Endometriose er en tilstand der livmorslimhinne (endometrium) er lokalisert andre steder enn i livmorhulen og fører til en betennelsestilstand. Endometriose er vanligvis lokalisert i bekkenorganene; på bukhinnen rundt livmoren, på egglederne eller eggstokkene, men kan også lokaliseres til tarm og urinblære.
+Endometriose er en tilstand der livmorslimhinne (endometrium) er lokalisert andre steder enn i livmorhulen og fører til en betennelsestilstand. Endometriose er vanligvis lokalisert i bekkenorganene; på bukhinnen rundt livmoren, på egglederne eller eggstokkene, men kan også lokaliseres til tarm og urinblære.
 
 Livmorslimhinnen gjennomgår sykliske forandringer under påvirkning av de kvinnelige kjønnshormonene østrogen og progesteron. Slimhinnen bygges opp for å være klar til å ta i mot et eventuelt befruktet egg. Mot slutten av syklusen faller hormonnivåene, noe som fører til at livmorslimhinnen støtes ut som menstruasjonsblødning. Det samme skjer med livmorslimhinne som er lokalisert andre steder enn i livmoren. Blod fra dette vevet skilles ikke ut, men «fanges» i små blodfylte knuter eller flyter fritt rundt i bukhulen.
 
@@ -215,7 +215,7 @@ Ved operasjoner for endometriose anbefales at man unngår åpen kirurgi. Åpen k
 
 ## Muskelknuter i livmor (myomer)
 
-2015–2017Godartede svulster som utgår fra muskulaturen i livmor kalles gjerne myomer eller muskelknuter. Myomer er hyppig forekommende og finnes hos rundt 70 % av fertile kvinner, men bare 15–30 % har symptomer. Vanlige symptomer er langvarige og/eller kraftige menstruasjonsblødninger og trykksymptomer mot blære og tarm. Muskelknuter øker risiko for nedsatt fertilitet og for problemer under svangerskap og fødsel.
+Godartede svulster som utgår fra muskulaturen i livmor kalles gjerne myomer eller muskelknuter. Myomer er hyppig forekommende og finnes hos rundt 70 % av fertile kvinner, men bare 15–30 % har symptomer. Vanlige symptomer er langvarige og/eller kraftige menstruasjonsblødninger og trykksymptomer mot blære og tarm. Muskelknuter øker risiko for nedsatt fertilitet og for problemer under svangerskap og fødsel.
 
 De fleste pasienter med myomer har ikke symptomer og trenger ingen behandling. Blødningsplager kan behandles med ulike hormoner. P-piller eller hormon-spiral kan bidra til å redusere kraftige blødninger. Ved store muskelknuter kan andre typer medikamenter brukes for å forsøke å skrumpe muskelknutene. Dette gjøres også som forbehandling til kirurgi.
 
@@ -247,7 +247,7 @@ Det var imidlertid stor variasjon i bruk av åpen kirurgi mellom de ulike opptak
 
 ## Kraftige og/eller hyppige blødninger
 
-2015–2017Blødningsforstyrrelse finnes hos ca. 15–20 % av kvinner i fertil alder. Blødningene kan være regelmessige med økt mengde blødning pr. menstruasjon, og/eller de kan være uregelmessige og ikke følge noen klar syklus.
+Blødningsforstyrrelse finnes hos ca. 15–20 % av kvinner i fertil alder. Blødningene kan være regelmessige med økt mengde blødning pr. menstruasjon, og/eller de kan være uregelmessige og ikke følge noen klar syklus.
 
 Hos tenåringer og hos kvinner som nærmer seg overgangsalder vil uregelmessig eggløsning kunne gi uregelmessige blødninger. Andre vanlige årsaker til blødningsforstyrrelser er forandringer i livmoren som fortykket slimhinne, polypper (utvekster på slimhinnen) eller myomer (muskelknuter i livmoren). Inneliggende kobberspiral, stoffskiftelidelser og blodsykdommer som påvirker blodets evne til å koagulere, kan gi kraftige blødninger med anemi som resultat. Hormonell prevensjon (hormonspiral, p-stav og p-sprøyte) kan gi uregelmessige blødninger. I noen tilfeller vil undersøkelse med tanke på underliggende ondartet sykdom være relevant.
 
@@ -273,7 +273,7 @@ Den geografiske variasjonen i bruk av operasjoner for kraftige og/eller hyppige 
 
 ## Hysterektomi og transcervikale inngrep
 
-2015–2017Kirurgisk fjerning av livmoren (hysterektomi) gjøres av flere grunner. Muskelknuter i livmoren, blødningsforstyrrelser og endometriose er mulige årsaker til at livmoren fjernes hos pasienter som ikke har kreft. Fjerning av livmoren kan gjøres åpent, laparoskopisk eller vaginalt. En del mindre inngrep på livmoren kan også gjøres ved å føre et instrument via skjeden og gjennom livmorhalsen (cervix). Denne typen inngrep kalles gjerne transcervikale inngrep og kan i noen tilfeller være et alternativ til å fjerne livmoren.
+Kirurgisk fjerning av livmoren (hysterektomi) gjøres av flere grunner. Muskelknuter i livmoren, blødningsforstyrrelser og endometriose er mulige årsaker til at livmoren fjernes hos pasienter som ikke har kreft. Fjerning av livmoren kan gjøres åpent, laparoskopisk eller vaginalt. En del mindre inngrep på livmoren kan også gjøres ved å føre et instrument via skjeden og gjennom livmorhalsen (cervix). Denne typen inngrep kalles gjerne transcervikale inngrep og kan i noen tilfeller være et alternativ til å fjerne livmoren.
 
 Ved hysterektomi for godartede tilstander lar man vanligvis eggstokkene stå igjen, spesielt hos kvinner som ikke er kommet i overgangsalder. Kvinnen vil derfor ikke få hormonelle plager etter behandlingen. Inngrepet kan gjøres åpent, laparoskopisk (med eller uten bruk av robot) eller vaginalt. I nasjonal veileder for gynekologi anbefales vaginal eller laparoskopisk teknikk.
 
@@ -301,7 +301,7 @@ Det er ingen kjent geografisk variasjon i sykelighet som skulle tilsi at behovet
 
 ## Skjede- og livmorfremfall
 
-2015–2017Bekkenorganene støttes opp av bindevev og muskulatur. Ved svekkelse av dette støtteapparatet kan det skje et såkalt fremfall eller descens av aktuelle organ via skjeden. Livmor med livmortappen kan synke ned i skjeden, urinblæren kan buke bakover og eventuelt ut av skjeden (cystocele) eller endetarmen kan buke fremover og eventuelt ut av skjeden (rektocele). Vanlige plager er at kvinnen merker en kul i skjedeåpningen, og kjenner på tyngdefølelse, har problemer ved vannlatning eller avføring.
+Bekkenorganene støttes opp av bindevev og muskulatur. Ved svekkelse av dette støtteapparatet kan det skje et såkalt fremfall eller descens av aktuelle organ via skjeden. Livmor med livmortappen kan synke ned i skjeden, urinblæren kan buke bakover og eventuelt ut av skjeden (cystocele) eller endetarmen kan buke fremover og eventuelt ut av skjeden (rektocele). Vanlige plager er at kvinnen merker en kul i skjedeåpningen, og kjenner på tyngdefølelse, har problemer ved vannlatning eller avføring.
 
 Graden av fremfall beskrives med fire kategorier fra grad 1 (minst alvorlig) til grad 4 (mest alvorlig, fullstendig fremfall). Ved et fullstendig fremfall kommer hele livmoren utenfor skjeden. Sannsynligvis forårsakes fremfall av flere faktorer. Økende alder, det å ha født flere barn, østrogenmangel, overvekt, tungt fysisk arbeid, obstipasjon og kronisk hoste gir økt risiko for tilstanden.
 
@@ -323,7 +323,7 @@ Den geografiske variasjonen i bruk av operasjoner for skjede- og livmorfremfall 
 
 ## Urininkontinens
 
-2015–2017Urininkontinens (urinlekkasje) er et hyppig fenomen hos kvinner. Norske tall viser at ca 25 % av den kvinnelige befolkningen over 20 år har noen grad av urininkontinens, og vel en tredjedel av disse er betydelig plaget. Forekomsten øker med økende alder.
+Urininkontinens (urinlekkasje) er et hyppig fenomen hos kvinner. Norske tall viser at ca 25 % av den kvinnelige befolkningen over 20 år har noen grad av urininkontinens, og vel en tredjedel av disse er betydelig plaget. Forekomsten øker med økende alder.
 
 Urininkontinens forekommer hyppigst hos kvinner som har født, men kan også forekomme hos kvinner som ikke har født. Urininkontinens kan for mange medføre reduksjon i livskvalitet, endre sosiale vaner og innskrenke fysisk utfoldelse.
 

--- a/_posts/tidligere_atlas/gyn.md
+++ b/_posts/tidligere_atlas/gyn.md
@@ -12,7 +12,7 @@ toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/helseatlas-gynekologi.pdf).
+Hovedfunnene er oppsummert under, hvor du også finner en kort beskrivelse av pasientutvalg. Det gis videre informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser pr. 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/helseatlas-gynekologi.pdf">rapporten</a>.
 </div>
 
 **Les mer:** [Opptaksområder og justering](/helseatlas/files/gyn_opptaksomr.pdf)

--- a/_posts/tidligere_atlas/kols.md
+++ b/_posts/tidligere_atlas/kols.md
@@ -6,14 +6,13 @@ num: 5
 mainTitle: Helseatlas kols
 shortTitle: Kols
 frontpagetext: Helseatlas kols beskriver variasjon i bruk av fastlege og legevakt, poliklinikk, akuttinnleggelser og rehabilitering i forhold til bosted for personer med kols.
-pdfUrl: /helseatlas/files/helseatlas-kols-rapport.pdf
 ia: true
 lang: nb
 toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene fra atlaset er oppsummert under, og du finner også en kort beskrivelse av pasientutvalgene. Det gis informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser per 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert
+Hovedfunnene fra atlaset er oppsummert under, og du finner også en kort beskrivelse av pasientutvalgene. Det gis informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser per 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/helseatlas-kols-rapport.pdf).
 </div>
 
 ## Fastlege og legevakt

--- a/_posts/tidligere_atlas/kols.md
+++ b/_posts/tidligere_atlas/kols.md
@@ -12,7 +12,7 @@ toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene fra atlaset er oppsummert under, og du finner også en kort beskrivelse av pasientutvalgene. Det gis informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser per 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/helseatlas-kols-rapport.pdf).
+Hovedfunnene fra atlaset er oppsummert under, og du finner også en kort beskrivelse av pasientutvalgene. Det gis informasjon om befolkningens bruk i geografiske områder (opptaksområder). Befolkningens bruk måles som antall hendelser per 10 000 innbyggere eller som andeler av pasientene som får en gitt tjeneste. Variasjonen i bruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/helseatlas-kols-rapport.pdf">rapporten</a>.
 </div>
 
 ## Fastlege og legevakt

--- a/_posts/tidligere_atlas/kvalitet.md
+++ b/_posts/tidligere_atlas/kvalitet.md
@@ -6,11 +6,12 @@ num: 11
 mainTitle: Helseatlas for kvalitet
 shortTitle: Kvalitet
 frontpagetext: Helseatlas for kvalitet i nødvendige helsetjenester er basert på informasjon om i underkant av 100 000 pasienter og behandlinger årlig, hvorav noen kan ha fått samme behandling flere ganger eller ha flere sykdommer.
-pdfUrl: /helseatlas/files/kvalitetsatlas.pdf
 ia: true
 lang: nb
 toc: true
 ---
+
+Dette er et sammendrag av Helseatlas for kvalitet. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/kvalitetsatlas.pdf).
 
 ## Samlede resultater
 
@@ -36,7 +37,7 @@ Helseatlaset gir oversikt over hvilke opptaksområder som har kvalitetsutfordrin
 
 For noen kvalitetsindikatorer var det utfordringer med lav måloppnåelse i alle opptaksregioner og i de fleste opptaksområder. Spesielt for disse indikatorene lever kvaliteten ikke opp til den faglige standarden som er satt, og årsakene til dette kan være mange og sammensatte. Det bør for disse områdene undersøkes nærmere hva årsakene til den lave måloppnåelsen var, og hvordan den kan bedres.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_samlet_res.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_samlet_res.pdf).
 
 ## Hjerteinfarkt
 
@@ -62,7 +63,7 @@ For utredning med kransårerøntgen skal minst 80 % av pasientene utredes innen 
 
 Nasjonalt er det utfordringer for utredning med kransårerøntgen ved NSTEMI hjerteinfarkt innen anbefalt tid. Måloppnåelsen er moderat for nesten alle opptaksområder og bør bedres. For reperfusjonsbehandling innen anbefalt tid ved STEMI hjerteinfarkt var kvalitetsutfordringen betydelig. Rask åpning av den tette blodåren vil ofte være det viktigste enkelttiltak i akuttfasen av et hjerteinfarkt. Den geografiske variasjonen var stor, og mange pasienter fikk ikke åpnet tette blodårer raskt nok. Trombolysebehandling er et behandlingsalternativ som kan gis før ankomst i spesialsykehus, prehospitalt eller i lokalsykehus, og som bør benyttes langt oftere ved STEMI hjerteinfarkt.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_hjerteinfarkt.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_hjerteinfarkt.pdf)
 
 ## Karkirurgi
 
@@ -88,7 +89,7 @@ Variasjon i antall pasienter operert for karsykdom i ben er uventet stor, og det
 
 Alle opptaksområder unntatt Bergen har oppnådd moderat eller høy måloppnåelse for indikatoren andel med symptomatisk carotisstenose behandlet innen anbefalt tid. En undersøkelse tyder på at knapt halvparten av tilfellene med forsinkelse skyldes forhold i helsetjenesten. Dette indikerer behov for systematisk arbeid med pasientforløp for denne gruppen i opptaksområder som ikke har høy måloppnåelse.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_karkirurgi.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_karkirurgi.pdf)
 
 ## Hjerneslag
 
@@ -116,7 +117,7 @@ Det var stor variasjon i andel pasienter behandlet med trombolyse i de ulike opp
 
 Ulik behandlingspraksis for de mindre alvorlige slagene er hovedårsaken til variasjonen i bruk av trombolyse. Forskjeller i behandlingspraksis for mindre alvorlige hjerneslag er ikke uproblematisk, fordi trombolysebehandling er forbundet med økt risiko for hjerneblødning, også ved lette og meget lette hjerneinfarkt. Målet på sikt bør være en mer ensartet praksis for behandling med trombolyse ved akutt hjerneinfarkt
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_hjerneslag.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_hjerneslag.pdf)
 
 ## Invasiv kardiologi
 
@@ -142,7 +143,7 @@ Om lag 20 % av pasientene i Norge fikk utført intrakoronar trykkmåling under k
 
 Resultatene kan tyde på at seleksjonen av pasienter til angiografi er strengere for pasienter bosatte i noen opptaksområder enn andre. Forskjellene skyldes trolig i hovedsak ulik tilgang eller praksis hva angår utredningsmetoder for kransåresykdom, som CT-undersøkelser eller ulike bildebaserte belastningstester som brukes til å selektere pasienter til koronar angiografi. Bruk av trykkmåling har i 2019 økt for 16 av 19 opptaksområder men må fortsatt breddes mye for å nå ønsket nivå.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_invasiv_kardio.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_invasiv_kardio.pdf)
 
 ## Tykk- og endetarmskreft
 
@@ -170,7 +171,7 @@ Kikkhullsteknikk ble i økende grad benyttet som operasjonsmetode, både for tyk
 
 Variasjonen i tilbakefall av endetarmskreft er ikke stor sammenlignet med omtale av annen variasjon, men likevel viktig. I mer enn 25 år er det arbeidet systematisk i norske fagmiljø for å redusere andel pasienter som får lokalt tilbakefall innen 5 år etter kurativ behandling for endetarmskreft. At hele syv opptaksområder ennå ikke har nådd høyt målnivå for denne indikatoren tyder på at det fortsatt er nødvendig med målrettet satsing for å lykkes.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_tarmkreft.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_tarmkreft.pdf)
 
 ## Brystkreft
 
@@ -194,7 +195,7 @@ De fleste av opptaksområdene hadde høy andel med ett kirurgisk inngrep og resu
 
 Det er positivt at de fleste av opptaksområdene klarte å behandle en høy andel av pasientene med ett inngrep på svulst i brystet. Det tyder på godt tverrfaglig samarbeid og god kvalitet i behandlingen. For brystbevarende operasjoner er måloppnåelsen moderat eller lav for de fleste opptaksområder og bør bedres. Den geografisk variasjon i måloppnåelse er relativt stor og tyder på at det gjøres ulike behandlingsvalg i ulike deler av landet. Brystbevarende operasjoner gir minst like god prognose som når hele brystet fjernes. Pasientenes selvfølelse og livskvalitet er vist å være bedre ved slik kirurgi, sammenlignet med fjerning av hele brystet.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_brystkreft.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_brystkreft.pdf)
 
 ## Lungekreft
 
@@ -220,7 +221,7 @@ Det var variasjon i median overlevelse i perioden 2017–2019. Ni av 21 opptakso
 
 Det er høy måloppnåelse for kurativ behandling av lungekreft i Norge, men likevel geografisk variasjon mellom opptaksområdene. Kirurgi nyttes i ulik grad som behandlingsmetode i de forskjellige opptaksområdene. Ulik fordeling i sykdomsutbredelse kan forklare ulike behandlingsvalg, men slike data var ikke tilgjengelig for denne analysen. Raskere utredning og bedre behandling har gitt lengre overlevelse for pasienter rammet av lungekreft, men det er en geografisk variasjon som ikke synes tilfeldig. Geografisk variasjon både i kurativ behandling og overlevelse bør undersøkes nærmere.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_lungekreft.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_lungekreft.pdf)
 
 ## Prostatakreft
 
@@ -248,7 +249,7 @@ Menn som har en høyrisiko-kreft uten spredning og som ikke gjennomfører en rad
 
 Måloppnåelsen er ikke tilfredstillende for andelen med fri rand etter kirurgi. Det er mulig at enkelte kirurger prioriterer nervesparende teknikk høyere enn andre, og at dette fører til lavere andel med fri rand i enkelte opptaksområder. Vurderingen av om operasjonsmarginen er fri eller ikke, er ikke et helt objektivt mål, men gjøres av den enkelte patolog. Praksis for hva som regnes for fri/ufri rand kan variere mellom patologer med konsekvens for det nasjonale bilde.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_prostatakreft.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_prostatakreft.pdf)
 
 ## Diabetes type 1 hos barn og unge
 
@@ -276,7 +277,7 @@ _Figur 2: _
 
 De fleste barn og unge når ikke behandlingsmålet når det kommer til regulering av blodsukkernivået. Nasjonalt var det geografisk variasjon både i andelen som hadde svært godt regulert blodsukker, og andelen som brukte CGM mellom opptaksområdene. Flere av opptaksområdene med høyest andel barn og unge med høy HbA1c hadde lavest andel som bruker CGM.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_barnediabetes.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_barnediabetes.pdf)
 
 ## Diabetes type 1 hos voksne
 
@@ -302,7 +303,7 @@ Når blodsukkeret er over eller lik 75 mmol/mol øker faren for å utvikle senko
 
 Måloppnåelsen for blodsukkerregulering er for lav i enkelte opptaksområder og det er geografisk variasjon i kvalitet i behandling av diabetes. Det er flere opptaksområder som både har høy andel pasienter med høyt blodsukker og som har lavere andel pasienter med svært godt regulert blodsukker.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_voksendiabetes.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_voksendiabetes.pdf)
 
 ## Hoftebrudd
 
@@ -330,7 +331,7 @@ Rask og god kirurgisk behandling er viktig for denne pasientgruppen. De fleste a
 
 Usementerte protesestammer er forbundet med økt risiko for nye brudd rundt protesen og dermed behov for reoperasjon for pasientgruppen over 70 år. Nasjonalt er det en tendens til utvikling i riktig retning i perioden. Variasjonen i behandlingspraksis er ikke tilfeldig og bør studeres nærmere.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_hoftebrudd.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_hoftebrudd.pdf)
 
 ## Alvorlig nyresykdom
 
@@ -356,4 +357,4 @@ Høy måloppnåelse er når 80 % av pasientene har en ukentlig Kt/V over fastsat
 
 Det er store geografiske forskjeller i måloppnåelse når det kommer til nyreerstattende behandling. Resultatene viser at måloppnåelsen for blodtrykkregulering er for lav for samtlige opptaksområder, og at nyretransplanterte pasienter ikke følges opp i tilstrekkelig grad etter nasjonale anbefalinger. Flere av opptaksområdene med høyest andel nyretransplanterte med blodtrykk over anbefalt nivå har også lavest andel pasienter med tilfredsstillende dialyseeffektivitet i hemodialyse.
 
-[Hovedfunn pdf](/helseatlas/files/kvalitet_nyre.pdf)
+Dette kapittelet finnes også som [en-sides pdf](/helseatlas/files/kvalitet_nyre.pdf)

--- a/_posts/tidligere_atlas/nyfodt.md
+++ b/_posts/tidligere_atlas/nyfodt.md
@@ -12,7 +12,7 @@ toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, og der finner du også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/norsk_nyfodtmedisinsk_helseatlas_rapport_0.pdf).
+Hovedfunnene er oppsummert under, og der finner du også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/norsk_nyfodtmedisinsk_helseatlas_rapport_0.pdf">rapporten</a>.
 </div>
 
 ## Innleggelser i nyfødtmedisinske avdelinger

--- a/_posts/tidligere_atlas/nyfodt.md
+++ b/_posts/tidligere_atlas/nyfodt.md
@@ -6,14 +6,13 @@ num: 3
 mainTitle: Norsk nyfødtmedisinsk helseatlas
 shortTitle: Nyfødtmedisin
 frontpagetext: Norsk nyfødtmedisinsk helseatlas omhandler alle nyfødte barn som har vært innlagt i avdelinger for syke nyfødte i Norge i perioden 2009 til 2014.
-pdfUrl: /helseatlas/files/norsk_nyfodtmedisinsk_helseatlas_rapport_0.pdf
 ia: true
 lang: nb
 toc: true
 ---
 
 <div className="ingress">
-Hovedfunnene er oppsummert under, og der finner du også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske boområdene er kort kommentert.
+Hovedfunnene er oppsummert under, og der finner du også en kort beskrivelse av pasientutvalgene. Det gis videre informasjon om befolkningens forbruk i geografiske områder (boområder). Befolkningens forbruk måles som antall kontakter pr. 100 000 innbyggere. Variasjonen i forbruk mellom de geografiske boområdene er kort kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/norsk_nyfodtmedisinsk_helseatlas_rapport_0.pdf).
 </div>
 
 ## Innleggelser i nyfødtmedisinske avdelinger

--- a/_posts/tidligere_atlas/ortopedi.md
+++ b/_posts/tidligere_atlas/ortopedi.md
@@ -12,7 +12,7 @@ toc: true
 lang: nn
 ---
 <div className="ingress">
-Hovudfunn frå Helseatlas i ortopedi for Noreg er oppsummert under. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (buområde/opptaksområde). Innbyggarane sin bruk blir målt som tal hendingar pr. 100 000 innbyggarar eller som prosentdelar av pasientane som får ei gitt teneste. Variasjonen i bruk mellom dei geografiske buområda er kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/rapport_ortopedi.pdf).
+Hovudfunn frå Helseatlas i ortopedi for Noreg er oppsummert under. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (buområde/opptaksområde). Innbyggarane sin bruk blir målt som tal hendingar pr. 100 000 innbyggarar eller som prosentdelar av pasientane som får ei gitt teneste. Variasjonen i bruk mellom dei geografiske buområda er kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/rapport_ortopedi.pdf">rapporten</a>.
 </div>
 
 ## Hofteleddsartrose

--- a/_posts/tidligere_atlas/ortopedi.md
+++ b/_posts/tidligere_atlas/ortopedi.md
@@ -7,13 +7,12 @@ shortTitle: Ortopedi
 image: /helseatlas/img/no/ortopedi/frontpage.jpg
 frontpagetext: I helseatlas i ortopedi for Noreg har vi kartlagt geografisk
   variasjon i bruk av spesialisthelsetenester innan ortopedi i 2012–2016.
-pdfUrl: /helseatlas/files/rapport_ortopedi.pdf
 ia: true
 toc: true
 lang: nn
 ---
 <div className="ingress">
-Hovudfunn frå Helseatlas i ortopedi for Noreg er oppsummert under. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (buområde/opptaksområde). Innbyggarane sin bruk blir målt som tal hendingar pr. 100 000 innbyggarar eller som prosentdelar av pasientane som får ei gitt teneste. Variasjonen i bruk mellom dei geografiske buområda er kommentert.
+Hovudfunn frå Helseatlas i ortopedi for Noreg er oppsummert under. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (buområde/opptaksområde). Innbyggarane sin bruk blir målt som tal hendingar pr. 100 000 innbyggarar eller som prosentdelar av pasientane som får ei gitt teneste. Variasjonen i bruk mellom dei geografiske buområda er kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/rapport_ortopedi.pdf).
 </div>
 
 ## Hofteleddsartrose

--- a/_posts/tidligere_atlas/psyk.md
+++ b/_posts/tidligere_atlas/psyk.md
@@ -13,7 +13,7 @@ toc: true
 lang: nn
 ---
 <div className="ingress">
-Hovudfunn frå Helseatlas for psykisk helsevern og rusbehandling er oppsummert under.  Helseatlaset gir oversikt og analyse i bruk av psykisk helsevern, inkludert avtalespesialistane, og tverrfagleg spesialisert behandling av ruslidingar (TSB) i Noreg  for åra 2014 - 2018. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (opptaksområde/buområde). Innbyggarane sin bruk blir målt som tal hendingar per 1 000 innbyggarar. Variasjonen i bruk mellom dei geografiske buområda er kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/psykiskhelsevernogrus.pdf).
+Hovudfunn frå Helseatlas for psykisk helsevern og rusbehandling er oppsummert under.  Helseatlaset gir oversikt og analyse i bruk av psykisk helsevern, inkludert avtalespesialistane, og tverrfagleg spesialisert behandling av ruslidingar (TSB) i Noreg  for åra 2014 - 2018. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (opptaksområde/buområde). Innbyggarane sin bruk blir målt som tal hendingar per 1 000 innbyggarar. Variasjonen i bruk mellom dei geografiske buområda er kommentert. Flere resultater og analyser finnes i <a href="/helseatlas/files/psykiskhelsevernogrus.pdf">rapporten</a>.
 </div>
 
 ## Barn og unge i psykisk helsevern

--- a/_posts/tidligere_atlas/psyk.md
+++ b/_posts/tidligere_atlas/psyk.md
@@ -8,13 +8,12 @@ image: /helseatlas/img/no/psyk/frontpage.jpg
 frontpagetext: Helseatlas for psykisk helsevern og rusbehandling gir oversikt
   over bruk av psykisk helsevern og tverrfagleg spesialisert rusbehandling, og
   analyserer geografisk variasjon i bruk av tenestene i Noreg i 2014–2018.
-pdfUrl: /helseatlas/files/psykiskhelsevernogrus.pdf
 ia: true
 toc: true
 lang: nn
 ---
 <div className="ingress">
-Hovudfunn frå Helseatlas for psykisk helsevern og rusbehandling er oppsummert under.  Helseatlaset gir oversikt og analyse i bruk av psykisk helsevern, inkludert avtalespesialistane, og tverrfagleg spesialisert behandling av ruslidingar (TSB) i Noreg  for åra 2014 - 2018. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (opptaksområde/buområde). Innbyggarane sin bruk blir målt som tal hendingar per 1 000 innbyggarar. Variasjonen i bruk mellom dei geografiske buområda er kommentert.
+Hovudfunn frå Helseatlas for psykisk helsevern og rusbehandling er oppsummert under.  Helseatlaset gir oversikt og analyse i bruk av psykisk helsevern, inkludert avtalespesialistane, og tverrfagleg spesialisert behandling av ruslidingar (TSB) i Noreg  for åra 2014 - 2018. Oppsummeringane inneheld også ei kort skildring av pasientutvala. Det blir vidare gitt informasjon om innbyggarane sin bruk av helsetenester i geografiske område (opptaksområde/buområde). Innbyggarane sin bruk blir målt som tal hendingar per 1 000 innbyggarar. Variasjonen i bruk mellom dei geografiske buområda er kommentert. Flere resultater og analyser finnes i [rapporten](/helseatlas/files/psykiskhelsevernogrus.pdf).
 </div>
 
 ## Barn og unge i psykisk helsevern


### PR DESCRIPTION
Brukere ser ikke den lille lenken som finnes oppe til høyre

Blir seende slik ut for kvalitetsatlaset:

![image](https://user-images.githubusercontent.com/136346/190624648-b3e9c86d-dda5-488b-8d8e-a1be8c140319.png)

Som nå ser sånn ut:

![image](https://user-images.githubusercontent.com/136346/190625240-be406d24-4ac2-4a5b-8cb0-fb5e1571d8b1.png)
